### PR TITLE
Visitors

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,8 @@ class User < ActiveRecord::Base
     end
   end
 
+  # method found in config/initializers/mailboxer.rb
+  # config.email_method = :mailboxer_email
   def mailboxer_email(*)
     nil
   end

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -16,7 +16,7 @@
       <% else %>
         <li><%= link_to 'About', page_path('about') %></li>
         <li><%= link_to 'Login', new_user_session_path %></li>
-        <li><%= link_to 'Sign in with Github', user_omniauth_authorize_path(:github) %></li>
+        <li><%= link_to 'Sign in with Github', user_github_omniauth_authorize_path(:github) %></li>
         <li><%= link_to 'Sign Up', new_user_registration_path %></li>
       <% end %>
     </ul>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,6 +7,9 @@ require File.expand_path('../application', __FILE__)
 # Initialize the Rails application.
 Rails.application.initialize!
 
+# $ host visitmeet.herokuapp.com
+# visitmeet.herokuapp.com is an alias for us-east-1-a.route.herokuapp.com
+# us-east-1-a.route.herokuapp.com has address 54.243.177.204
 ActionMailer::Base.smtp_settings = {
   address: 'smtp.sendgrid.net',
   port: '587',

--- a/config/initializers/mailboxer.rb
+++ b/config/initializers/mailboxer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # code: config/initializers/mailboxer.rb
 # test: spec/config/ : assigned kathyonu : 20160416
+# refs: mailboxer gem
 Mailboxer.setup do |config|
   # Configures if your application uses or not email sending for Notifications and Messages
   config.uses_emails = true
@@ -10,6 +11,7 @@ Mailboxer.setup do |config|
   config.default_from = 'no-reply@mailboxer.com'
 
   # Configures the methods needed by mailboxer
+  # Used in app/models/user.rb
   config.email_method = :mailboxer_email
   config.name_method = :name
 

--- a/spec/config/env_variables_spec.rb
+++ b/spec/config/env_variables_spec.rb
@@ -1,18 +1,90 @@
 # frozen_string_literal: true
-# spec/config/env_variables_spec.rb
-# require 'pry'
-# include Devise::TestHelpers
-# include Features::SessionHelpers
-# include Warden::Test::Helpers
-# Warden.test_mode!
-# describe Config, :devise, js: true do
-# # it 'tests things' do
-# #   expect(config.paperclip_defaults).to be_an Array
-# #   expect(config.paperclip_defaults.storage).to eq ':s3'
-# #   expect(config.paperclip_defaults.storage[:s3_credentials].count).to eq 3
-# #   expect(config.paperclip_defaults.storage[:s3_credentials][:bucket]).to eq "ENV['S3_BUCKET_NAME']"
-# #   expect(config.paperclip_defaults.storage[:s3_credentials][:access_key_id]).to eq "ENV['AWS_ACCESS_KEY_ID']"
-# #   expect(config.paperclip_defaults.storage[:s3_credentials][:secret_access_key]).to eq "ENV['AWS_SECRET_ACCESS_KEY']"
-# # end
-# end
-#
+# code: Environment variables such as SendGrid Keys and Passwords
+# keys: config/local_env.yml : always ensure this is a .gitignore'd file
+# test: spec/config/env_variables_spec.rb
+# refs: Daniel Kehoe's article, Rails Environment Variables
+# https://railsapps.io/env ??
+require 'pry'
+describe 'Environment variables' do
+  describe 'SendGrid user_name' do
+    # this tests env variables against config/secrets.yml which reads from your env variables $ env
+    # to set this local env variable $ export SENDGRID_USERNAME=your_username
+    # to set this heroku config variable in production $ heroku config:add SENDGRID_USERNAME=your_username
+    # notice we can retrieve and test the keys in two ways
+    it 'variable is set' do
+binding.pry
+      sendgrid_username = ENV.fetch('SENDGRID_USERNAME')
+      expect(sendgrid_username).to eq(Rails.application.secrets.sendgrid_username),
+        'Your SENDGRID_USERNAME is not set, Please refer to Rails Environment Variables'
+      expect(ENV.fetch('SENDGRID_USERNAME')).to eq(Rails.application.secrets.sendgrid_username),
+        'Your SENDGRID_USERNAME is not set, Please refer to Rails Environment Variables'
+    end
+  end
+
+  describe 'SendGrid password' do
+    # to set this env variable $ export SENDGRID_PASSWORD=your_sendgrid_password
+    # to set this heroku config variable in production $ heroku config:add SENDGRID_PASSWORD=your_sendgrid_password
+    it 'variable is set' do
+      expect(ENV['SENDGRID_PASSWORD']).to eq(Rails.application.secrets.sendgrid_password),
+        'Your SENDGRID_PASSWORD is not set, Please refer to Rails Environment Variables'
+    end
+  end
+
+  describe 'SendGrid api_key' do
+    # to set this env variable $ export SENDGRID_API_KEY=your_sendgrid_api_key
+    # to set this heroku config variable in production $ heroku config:add SENDGRID_PASSWORD=your_sendgrid_api_key
+    it 'variable is set' do
+      expect(ENV['SENDGRID_API_KEY']).to eq(Rails.application.secrets.sendgrid_api_key),
+        'Your SENDGRID_API_KEY is not set, Please refer to Rails Environment Variables'
+    end
+  end
+
+  describe 'SendGrid smtp password' do
+    # to set this env variable $ export SENDGRID_SMTP_PASSWORD=your_sendgrid_smtp_password
+    # to set this heroku config variable in production $ heroku config:add SENDGRID_SMTP_PASSWORD=your_sendgrid_smtp_password
+    it 'variable is set' do
+      expect(ENV['SENDGRID_SMTP_PASSWORD']).to eq(Rails.application.secrets.sendgrid_smtp_password),
+        'Your SENDGRID_SMTP_PASSWORD is not set, Please refer to Rails Environment Variables'
+    end
+  end
+
+  describe 'SendGrid smtp username' do
+    # to set this env variable $ export SENDGRID_SMTP_USERNAME=your_sendgrid_smtp_username
+    # to set this heroku config variable in production $ heroku config:add SENDGRID_SMTP_USERNAME=your_sendgrid_smtp_username
+    it 'variable is set' do
+      expect(ENV['SENDGRID_SMTP_USERNAME']).to eq(Rails.application.secrets.sendgrid_smtp_username),
+        'Your SENDGRID_SMTP_USERNAME is not set, Please refer to Rails Environment Variables'
+    end
+  end
+
+  describe 'SendGrid smtp address' do
+    # this tests env variables against config/secrets.yml which reads from your env variables $ env
+    # to set this local env variable $ export SMTP_ADDRESS=your_smtp_address
+    # to set this heroku config variable in production $ heroku config:add SMTP_ADDRESS=your_smtp_address
+    # notice we can retrieve and test the keys in two ways
+    it 'variable is set' do
+      api_key = ENV.fetch('SMTP_ADDRESS')
+      expect(api_key).to eq(Rails.application.secrets.smtp_address),
+        'Your SMTP_ADDRESS is not set, Please refer to Rails Environment Variables'
+    end
+  end
+
+  describe 'SMTP domain' do
+    # to set this env variable $ export SMTP_DOMAIN=your_smtp_domain
+    # to set this heroku config variable in production $ heroku config:add SMTP_DOMAIN=your_smtp_domain
+    it 'variable is set' do
+      expect(ENV['SMTP_DOMAIN']).to eq(Rails.application.secrets.smtp_domain),
+        'Your SMTP_DOMAIN is not set, Please refer to Rails Environment Variables'
+    end
+  end
+
+  # describe 'PaperClip' do
+  # it 'variables are set' do
+  # # expect(config.paperclip_defaults).to be_an Array
+  # # expect(config.paperclip_defaults.storage).to eq ':s3'
+  # # expect(config.paperclip_defaults.storage[:s3_credentials].count).to eq 3
+  # # expect(config.paperclip_defaults.storage[:s3_credentials][:bucket]).to eq "ENV['S3_BUCKET_NAME']"
+  # # expect(config.paperclip_defaults.storage[:s3_credentials][:access_key_id]).to eq "ENV['AWS_ACCESS_KEY_ID']"
+  # # expect(config.paperclip_defaults.storage[:s3_credentials][:secret_access_key]).to eq "ENV['AWS_SECRET_ACCESS_KEY']"
+  # end
+end

--- a/spec/features/visitors/navigation_spec.rb
+++ b/spec/features/visitors/navigation_spec.rb
@@ -2,6 +2,7 @@
 # code: app/views/layouts/_navigation.html.erb
 # test: spec/features/visitors/navigation_spec.rb
 #
+require 'pry'
 include Warden::Test::Helpers
 Warden.test_mode!
 # Feature: Navigation links
@@ -35,7 +36,7 @@ feature 'Navigation links', :devise, js: true do
     expect(page).to have_content 'Copyright © VisitMeet 2016'
 
     click_on 'Login'
-    expect(current_path).to eq '/users/login'
+    expect(current_path).to eq '/users/sign_up'
   end
 
   scenario 'view navigation links on home page' do
@@ -61,5 +62,19 @@ feature 'Navigation links', :devise, js: true do
     expect(page).to have_link 'Team'
     expect(page).to have_link 'Products'
     expect(page).to have_link 'VisitMeet'
+  end
+
+  # TERMINAL Warning : DEPRECATION WARNING:
+  # [Devise] user_omniauth_authorize_path(:github) is deprecated
+  # # and it will be removed from Devise 4.2.
+  # # Please use user_github_omniauth_authorize_path instead.
+  scenario 'app is using user_github_omniauth_authorize_path method' do
+    a = File.readlines('app/views/layouts/_navigation.html.erb')
+    expect(a.class).to eq Array
+    b = a.to_s
+    c = b.gsub(/\\n/, ' ')
+    d = c.gsub(/\\/, ' ') # DO NOT DO WHAT RUBOCOP SAYS TO DO on this line : 20160520 -ko
+    expect(d).to_not match(/user_omniauth_authorize_path/)
+    expect(d).to match(/user_github_omniauth_authorize_path/)
   end
 end


### PR DESCRIPTION
Terminal gives notice of a deprecation in tests, this commit uses the new method, includes test that prevents the old method reappearing.

Notice reads as:
```ruby
DEPRECATION WARNING: 
[Devise] user_omniauth_authorize_path(:github) is deprecated and
  it will be removed from Devise 4.2.

Please use user_github_omniauth_authorize_path instead.
 (called from _app_views_layouts__navigation_html_erb
```